### PR TITLE
Update to latest bower specifications and show how to configure AMD loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,40 @@ or [Yeoman](http://yeoman.io/)
 
 ## Usage
 
-The prettify script is AMD compatible and can be used modularly. Here is an example of it using RequireJS:
+The prettify script is AMD compatible and can be used modularly. Here is an example of it in an AMD module:
 
 ```javascript
-	define(['jquery', 'prettify'], function($, prettify){
-		var code = null;
-		$('pre').addClass('prettyprint').each(function(idx, el){
-				code = el.firstChild;
-				code.innerHTML = prettify.prettyPrintOne(code.innerHTML);
-			})
-		);
-	});
+define(['jquery', 'prettify'], function($, prettify){
+	var code = null;
+	$('pre').addClass('prettyprint').each(function(idx, el){
+			code = el.firstChild;
+			code.innerHTML = prettify.prettyPrintOne(code.innerHTML);
+		})
+	);
+});
+```
+
+This version of google-code-prettify defines an anonymous module, which is more flexible.  To allow your AMD loader to find google-code-prettify with a more convenient name, map a path to it as follows:
+
+```js
+// using RequireJS
+require.config({
+	prettify: 'bower_components/google-code-prettify/prettify'
+});
+
+// using curl.js
+curl.config({
+	prettify: 'bower_components/google-code-prettify/prettify'
+});
 ```
 
 Or it may just be used in a global context like the following:
 
 ```javascript
-	(function(){
-		$('pre').addClass('prettyprint');
-		prettyPrint();
-	})();
+(function(){
+	$('pre').addClass('prettyprint');
+	prettyPrint();
+})();
 ```
 
 More information can be found in the original [README.html](http://google-code-prettify.googlecode.com/svn/trunk/README.html)

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+	"name": "google-code-prettify",
+	"version": "1.0.1",
+	"main": "./src/prettify.js",
+	"dependencies": {},
+	"ignore": [
+		"closure-compiler",
+		"js-modules",
+		"tests",
+		"yui-compressor",
+		"Makefile"
+	]
+}

--- a/component.json
+++ b/component.json
@@ -1,6 +1,0 @@
-{
-	"name": "google-code-prettify",
-	"version": "1.0.0",
-	"main": ["./src/prettify.js", "./styles/sons-of-obsidian.css"],
-	"dependencies": {}
-}


### PR DESCRIPTION
- Rename component.json to bower.json.
- Only include the module in "main" until the specification is finalized.
- Add instructions in the README to show how to configure an AMD loader.
- Ignore files that bower users don't want (Makefile, etc.).
- Bump version.
