### PR TITLE
Fixed Invalid CSS

### DIFF
--- a/styles/doxy.css
+++ b/styles/doxy.css
@@ -51,7 +51,7 @@ li.L1,li.L3,li.L5,li.L7,li.L9 { }
   pre.prettyprint, code.prettyprint { background-color: #fff;  }
   pre .str, code .str { color: #088; }
   pre .kwd, code .kwd { color: #006; font-weight: bold; }
-  pre .com, code .com { color: #oc3; font-style: italic; }
+  pre .com, code .com { color: #0C3; font-style: italic; }
   pre .typ, code .typ { color: #404; font-weight: bold; }
   pre .lit, code .lit { color: #044; }
   pre .pun, code .pun { color: #440; }


### PR DESCRIPTION
Sass::SyntaxError: Invalid CSS after "... .com { color: ": expected expression (e.g. 1px, bold), was "#oc3; font-styl..."
  (in /app/vendor/assets/bower_components/google-code-prettify/styles/doxy.css)