### PR TITLE
Add package.json and npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+closure-compiler
+js-modules
+tests
+yui-compressor
+Makefile

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "google-code-prettify",
+	"version": "1.0.1",
+	"dependencies": {}
+}


### PR DESCRIPTION
Hi! I'd like to add a `package.json` and `.npmignore`; this will allow this repo to be pulled in from NPM.

We're in the middle of migrating our components from Bower to NPM; [here's a good post as to why](https://roost.bocoup.com/blog/doubling-down-on-npm/).

Anyhow, merging this change this would be enough to let us move forward (we can reference the package as `tcollard/google-code-prettify`, but it would be even cooler if you published it to NPM directly, in which case you'd also want to update the README.

Thanks!