### PR TITLE
Removed the ability to load remote stylesheets because, well...

### DIFF
--- a/js-modules/run_prettify.js
+++ b/js-modules/run_prettify.js
@@ -216,7 +216,7 @@
         + '/skins/' + encodeURIComponent(skins[i]) + '.css');
   }
   skinUrls.push(LOADER_BASE_URL + '/prettify.css');
-  loadStylesheetsFallingBack(skinUrls);
+  //loadStylesheetsFallingBack(skinUrls);
 
   var prettyPrint = (function () {
     include("prettify.js");


### PR DESCRIPTION
…they don't exist anymore. 

![image](https://cloud.githubusercontent.com/assets/3081566/15303381/b80689c2-1b74-11e6-8982-fea64ea6eee6.png)

